### PR TITLE
Allow for an optional drag handle to be specified

### DIFF
--- a/src/jquery.draggable.js
+++ b/src/jquery.draggable.js
@@ -14,7 +14,8 @@
         limit: true,
         offset_left: 0,
         autoscroll: true,
-        ignore_dragging: ['INPUT', 'TEXTAREA', 'SELECT', 'BUTTON']
+        ignore_dragging: ['INPUT', 'TEXTAREA', 'SELECT', 'BUTTON'],
+        handle: ''
         // ,drag: function(e){},
         // start : function(e, ui){},
         // stop : function(e){}
@@ -58,6 +59,7 @@
       this.options = $.extend({}, defaults, options);
       this.$body = $(document.body);
       this.$container = $(el);
+      this.$handle = this.options.handle;
       this.$dragitems = $(this.options.items, this.$container);
       this.is_dragging = false;
       this.player_min_left = 0 + this.options.offset_left;
@@ -329,7 +331,15 @@
     };
 
     fn.ignore_drag = function(event) {
-        return $.inArray(event.target.nodeName, this.options.ignore_dragging) >= 0;
+        if (this.$handle.length > 0) {
+            if ($(event.target).is(this.$handle)) {
+                return false;
+            } else {
+                return true;
+            }
+        } else {
+            return $.inArray(event.target.nodeName, this.options.ignore_dragging) >= 0;
+        }
     };
 
     //jQuery adapter


### PR DESCRIPTION
When defining the gridster, you can now define a draggable.handle selector:

For example:

``` javascript
    $("#widgets").gridster({
        widget_margins: [10, 10],
        widget_base_dimensions: [140, 140],
        draggable: {
            handle: '.title'
        }
    });
```

If handle is omitted (or left blank), it works as it did previously. If a value is specified, then dragging only starts if the element which was clicked matches the selector specified.
