### PR TITLE
Allow widget dimensions to be resized.

### DIFF
--- a/dist/jquery.gridster.css
+++ b/dist/jquery.gridster.css
@@ -1,4 +1,4 @@
-/*! gridster.js - v0.1.0 - 2012-10-20
+/*! gridster.js - v0.1.0 - 2012-11-02
 * http://gridster.net/
 * Copyright (c) 2012 ducksboard; Licensed MIT */
 

--- a/dist/jquery.gridster.js
+++ b/dist/jquery.gridster.js
@@ -1,4 +1,4 @@
-/*! gridster.js - v0.1.0 - 2012-10-20
+/*! gridster.js - v0.1.0 - 2012-11-02
 * http://gridster.net/
 * Copyright (c) 2012 ducksboard; Licensed MIT */
 

--- a/dist/jquery.gridster.with-extras.js
+++ b/dist/jquery.gridster.with-extras.js
@@ -1,4 +1,4 @@
-/*! gridster.js - v0.1.0 - 2012-10-20
+/*! gridster.js - v0.1.0 - 2012-11-02
 * http://gridster.net/
 * Copyright (c) 2012 ducksboard; Licensed MIT */
 
@@ -3245,6 +3245,21 @@
                 return true;
             }
         }
+
+        return false;
+    };
+
+    fn.resize_widget_dimensions = function(options) { 
+        if (options.widget_margins) { 
+          this.options.widget_margins = options.widget_margins; 
+        } 
+        if (options.widget_base_dimensions) {  
+          this.options.widget_base_dimensions = options.widget_base_dimensions; 
+        }                          
+
+        this.generate_grid_and_stylesheet(); 
+        this.get_widgets_from_DOM(); 
+        this.set_dom_grid_height(); 
 
         return false;
     };

--- a/src/jquery.gridster.extras.js
+++ b/src/jquery.gridster.extras.js
@@ -16,6 +16,21 @@
         return false;
     };
 
+    fn.resize_widget_dimensions = function(options) { 
+        if (options.widget_margins) { 
+          this.options.widget_margins = options.widget_margins; 
+        } 
+        if (options.widget_base_dimensions) {  
+          this.options.widget_base_dimensions = options.widget_base_dimensions; 
+        }                          
+
+        this.generate_grid_and_stylesheet(); 
+        this.get_widgets_from_DOM(); 
+        this.set_dom_grid_height(); 
+
+        return false;
+    };
+
     fn.widgets_in_row = function(row) {
         for (var i = this.gridmap.length; i >= 1; i--) {
             if (this.is_widget(i, row) !== false) {


### PR DESCRIPTION
After defining the gridster, you can update the widget_base_dimensions and/or widget_margins using resize_widget_dimensions.

Example:

``` javascript
$('.gridster ul').gridster({
    widget_margins: [10, 10],
    widget_base_dimensions: [140, 140]
 });
var gridster = $('.gridster ul').gridster().data('gridster');
gridster.resize_widget_dimensions({widget_base_dimensions: [100,  100]});

```

We needed the ability to resize the dimensions and margins on window resize for a work project, so I modified jquery.gridster.with-extras.js and added a function to do so. 

I have an example of it in action here: http://jc-2.github.com/gridster-test/
