### PR TITLE
Add setting for maximum number of columns

### DIFF
--- a/src/jquery.gridster.js
+++ b/src/jquery.gridster.js
@@ -15,6 +15,7 @@
         extra_rows: 0,
         extra_cols: 0,
         min_cols: 1,
+        max_cols: -1,
         min_rows: 15,
         max_size_x: 6,
         autogenerate_stylesheet: true,
@@ -55,6 +56,8 @@
     *    @param {Number} [options.extra_rows] Add more rows in addition to
     *     those that have been calculated.
     *    @param {Number} [options.min_cols] The minimum required columns.
+    *    @param {Number} [options.max_cols] The maximum columns possible (set to -1
+    *     for no maximum).
     *    @param {Number} [options.min_rows] The minimum required rows.
     *    @param {Number} [options.max_size_x] The maximum number of columns
     *     that a widget can span.
@@ -2509,6 +2512,12 @@
         });
 
         this.cols = Math.max(min_cols, cols, this.options.min_cols);
+        var max_cols = this.options.max_cols;
+        if (max_cols >= -1 && max_cols >= min_cols) {
+            if (max_cols < this.cols) {
+                this.cols = max_cols;
+            }
+        }
         this.rows = Math.max(max_rows, this.options.min_rows);
 
         this.baseX = ($(window).width() - aw) / 2;


### PR DESCRIPTION
Right now the number of columns is calculated by dividing the available
space by the necessary space. I want to have an option to limit the
number of calculated columns, without changing the width of the div my
grid lives in.

In order to limit the number of calculated columns max_cols is set to a
number. To have 'unlimited' columns set the value of max_cols to -1 (as
is done in the default settings). This provides the arbitrary useful
functionality to set the max number of columns to 0. Any sideeffect
caused by this is mitigated by checking that the max_cols is larger
than the min_cols setting.
