### PR TITLE
The preview holder should not always use <li>

### DIFF
--- a/src/jquery.gridster.js
+++ b/src/jquery.gridster.js
@@ -706,7 +706,7 @@
         this.collision_api = this.$helper.collision(
             colliders, this.options.collision);
 
-        this.$preview_holder = $('<li />', {
+        this.$preview_holder = $('<' + this.$player.get(0).tagName + ' />', {
               'class': 'preview-holder',
               'data-row': this.$player.attr('data-row'),
               'data-col': this.$player.attr('data-col'),


### PR DESCRIPTION
Use the same element as the original widget for the preview holder. Using a `<li>` can cause a list item bullet to be displayed when widgets are not necessarily `<li>` elements.
