### PR TITLE
Orphan preview holder when dragging is interrupted

### DIFF
--- a/src/jquery.gridster.js
+++ b/src/jquery.gridster.js
@@ -645,6 +645,13 @@
             offset_left: this.options.widget_margins[0],
             container_width: this.container_width,
             start: function(event, ui) {
+                // Ignore drag start if mouse was released outside screen on a previous drag
+                if (self.dragging) {
+                    return;
+                }
+
+                self.dragging = true;
+
                 self.$widgets.filter('.player-revert')
                     .removeClass('player-revert');
 
@@ -657,6 +664,7 @@
                 self.$el.trigger('gridster:dragstart');
             },
             stop: function(event, ui) {
+                self.dragging = false;
                 self.on_stop_drag.call(self, event, ui);
                 self.$el.trigger('gridster:dragstop');
             },


### PR DESCRIPTION
After beginning a drag, if the mouse button is released outside of the screen, and if a subsequent drag operation is begun on another widget (while the previous widget still follows the mouse around), Draggable will trigger a new drag start event, causing Gridster to leave the current widget + its preview holder aside and start dragging the new widget. This will lead to an orphan preview holder to be left on the screen.

A quick solution is to ignore drag start without receiving a drag stop.
