### PR TITLE
remove_widget Returns the instance of the Gridster Class

### DIFF
--- a/src/jquery.gridster.js
+++ b/src/jquery.gridster.js
@@ -479,6 +479,8 @@
                 callback.call(this, el);
             }
         }, this));
+
+        return this;
     };
 
 


### PR DESCRIPTION
Following same pattern as remove_all_widgets --> remove_widget also return _this_ (as per inlined comment documentation)
