### PR TITLE
Updated node package dependencies to work on clean system.

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   ],
   "keywords": [],
   "dependencies": {
-    "jquery": "~2.0.0"
+    "jquery": "git+https://github.com/jquery/jquery.git#2.0.3"
   },
   "devDependencies": {
     "grunt": "~0.4.1",
@@ -34,7 +34,7 @@
     "grunt-contrib-cssmin": "~0.5.0",
     "grunt-contrib-yuidoc": "~0.4.0",
     "bower": "~0.9.2",
-    "qunit": "~1.11.0",
+    "qunitjs": "~1.11.0",
     "grunt-bump": "0.0.11",
     "grunt-conventional-changelog": "~1.0.0"
   }


### PR DESCRIPTION
 qunit->qunitjs and jquery 2.0 isn't listed in npm repository so replaced it with the git location.
