### PR TITLE
Fix leaking options with multiple Gridster instances

### DIFF
--- a/src/jquery.gridster.js
+++ b/src/jquery.gridster.js
@@ -110,7 +110,7 @@
     * @constructor
     */
     function Gridster(el, options) {
-        this.options = $.extend(true, defaults, options);
+        this.options = $.extend(true, {}, defaults, options);
         this.$el = $(el);
         this.$wrapper = this.$el.parent();
         this.$widgets = this.$el.children(


### PR DESCRIPTION
`defaults` was being overwritten.

See [jQuery documentation](http://api.jquery.com/jQuery.extend/):

> Keep in mind that the target object (first argument) will be modified, and will also be returned from $.extend().
