### PR TITLE
bugfix for add_widget - add_faux_rows was not working with bigger (bigge...

### DIFF
--- a/dist/jquery.gridster.js
+++ b/dist/jquery.gridster.js
@@ -958,7 +958,7 @@
 
         this.register_widget($w);
 
-        this.add_faux_rows(pos.size_y);
+        this.add_faux_rows(size_y);
         //this.add_faux_cols(pos.size_x);
 
         if (max_size) {


### PR DESCRIPTION
If you add a bigger widget (it has more rows than min_rows or actual_rows), only one row was added because the used variable in add_widget was invalid. That means, not enough stylesheet definitions were created.
