### PR TITLE
Update comments and cleared generated_stylesheets

### DIFF
--- a/src/jquery.gridster.js
+++ b/src/jquery.gridster.js
@@ -2689,13 +2689,14 @@
 
 
     /**
-    * Remove the style tag with the associated id from the head of the document
+    * Remove the style tags from the head of the document
     *
-    * @method  remove_style_tag
+    * @method  remove_style_tags
     * @return {Object} Returns the instance of the Gridster class.
     */
     fn.remove_style_tags = function() {
         this.$style_tags.remove();
+        Gridster.generated_stylesheets = [];
     };
 
 


### PR DESCRIPTION
Updated the function comments to better describe what the function does. Also added a line to clear the generated_stylesheets array cache when the tags are removed. That way they can be added back later without failing during the cache check. This last part because most useful on single page apps where the grid is destroyed and then recreated in the same session (no page refresh being done).
