### PR TITLE
fixed default value for resize axes

### DIFF
--- a/src/jquery.gridster.js
+++ b/src/jquery.gridster.js
@@ -35,7 +35,7 @@
         },
         resize: {
             enabled: false,
-            axes: ['x', 'y', 'both'],
+            axes: ['both'],
             handle_append_to: '',
             handle_class: 'gs-resize-handle',
             max_size: [Infinity, Infinity]


### PR DESCRIPTION
With resize.axes ['x','y',both'] by default any option defined in resize.axes will be discarded 
