### PR TITLE
Prevent multi <style> generation

### DIFF
--- a/src/jquery.gridster.js
+++ b/src/jquery.gridster.js
@@ -2808,18 +2808,21 @@
     */
     fn.add_style_tag = function(css) {
       var d = document;
-      var tag = d.createElement('style');
+      if(!document.getElementById('gridster-stylesheet')){
+        var tag = d.createElement('style');
+        tag.id = 'gridster-stylesheet';
 
-      d.getElementsByTagName('head')[0].appendChild(tag);
-      tag.setAttribute('type', 'text/css');
+        d.getElementsByTagName('head')[0].appendChild(tag);
+        tag.setAttribute('type', 'text/css');
 
-      if (tag.styleSheet) {
-        tag.styleSheet.cssText = css;
-      }else{
-        tag.appendChild(document.createTextNode(css));
+        if (tag.styleSheet) {
+          tag.styleSheet.cssText = css;
+        }else{
+          tag.appendChild(document.createTextNode(css));
+        }
+
+        this.$style_tags = this.$style_tags.add(tag);
       }
-
-      this.$style_tags = this.$style_tags.add(tag);
 
       return this;
     };


### PR DESCRIPTION
If the autogenerate_stylesheet option is set to true then the library is adding multiple times the same style on the head of the document (see the source of the http://gridster.net/demos/adding-widgets-dynamically.html demo in order to observe this). With this correction the gridster style element is only inserted once on the head
