### PR TITLE
fix add_widget to use correct size_y when adding rows

### DIFF
--- a/src/jquery.gridster.js
+++ b/src/jquery.gridster.js
@@ -230,7 +230,9 @@
         }else{
             pos = {
                 col: col,
-                row: row
+                row: row,
+                size_x: size_x,
+                size_y: size_y
             };
 
             this.empty_cells(col, row, size_x, size_y);


### PR DESCRIPTION
The call to this.add_faux_rows on 252 used to get passed null whenever col/row were defined for a new widget. This led to only a single row being added to the faux grid and insufficient css rules being generated in generate_stylesheet. 

http://jsfiddle.net/uHcHq/

Try dragging the 1 box on top of the 0 and then the 2 box on top of either the 0 or 1.
