### PR TITLE
Fixed issue where widget position would be overwritten on gridmap

### DIFF
--- a/dist/jquery.gridster.js
+++ b/dist/jquery.gridster.js
@@ -3689,7 +3689,7 @@
             this.gridmap[col] = [];
         }
 
-        if( typeof this.gridmap[col][row] === undefined ){
+        if( typeof this.gridmap[col][row] === "undefined" ){
             this.gridmap[col][row] = false;
         }
         

--- a/dist/jquery.gridster.js
+++ b/dist/jquery.gridster.js
@@ -3689,7 +3689,10 @@
             this.gridmap[col] = [];
         }
 
-        this.gridmap[col][row] = false;
+        if( typeof this.gridmap[col][row] === undefined ){
+            this.gridmap[col][row] = false;
+        }
+        
         this.faux_grid.push(coords);
 
         return this;


### PR DESCRIPTION
This fixes an issue where widget position would be overwritten on gridmap inside add_faux_cell ().

To reproduce add these widgets in the following order:

``` javascript
gridster.add_widget('<li class="new">The HTML of the widget...</li>', 2, 1, 1, 2);
gridster.add_widget('<li class="new">The HTML of the widget...</li>', 2, 1, 1, 3);
gridster.add_widget('<li class="new">The HTML of the widget...</li>', 2, 1, 1, 1);
```

The grid wrapper will only wrap around the 3rd element, with the first two overflowing. It's easiest to see by adding some background colours to the elements and wrapper.
