### PR TITLE
add_resize_handle: multiple span (resizeable) entries in widgets

### DIFF
--- a/src/jquery.gridster.js
+++ b/src/jquery.gridster.js
@@ -429,8 +429,11 @@
     * @return {HTMLElement} Returns instance of gridster Class.
     */
     fn.add_resize_handle = function($w) {
-        var append_to = this.options.resize.handle_append_to;
-        $(this.resize_handle_tpl).appendTo( append_to ? $(append_to, $w) : $w);
+        var $append_to = this.options.resize.handle_append_to ? $(this.options.resize.handle_append_to, $w) : $w;
+
+        if ( ($append_to.children("span[class~='" + this.resize_handle_class + "']")).length == 0 ) {
+            $(this.resize_handle_tpl).appendTo( $append_to );
+        }
 
         return this;
     };


### PR DESCRIPTION
On init() or get_widgets_from_DOM() new span entries are added to the
widgets container on every call again.
