### PR TITLE
Wrong addition solved in add_faux_rows by adding parseInt

### DIFF
--- a/dist/jquery.gridster.js
+++ b/dist/jquery.gridster.js
@@ -3795,7 +3795,7 @@
     */
     fn.add_faux_rows = function(rows) {
         var actual_rows = this.rows;
-        var max_rows = actual_rows + (rows || 1);
+        var max_rows = actual_rows + parseInt(rows || 1);
 
         for (var r = max_rows; r > actual_rows; r--) {
             for (var c = this.cols; c >= 1; c--) {

--- a/dist/jquery.gridster.js
+++ b/dist/jquery.gridster.js
@@ -3821,7 +3821,7 @@
     */
     fn.add_faux_cols = function(cols) {
         var actual_cols = this.cols;
-        var max_cols = actual_cols + (cols || 1);
+        var max_cols = actual_cols + parseInt(cols || 1);
         max_cols = Math.min(max_cols, this.options.max_cols);
 
         for (var c = actual_cols + 1; c <= max_cols; c++) {

--- a/src/jquery.gridster.js
+++ b/src/jquery.gridster.js
@@ -2960,7 +2960,7 @@
     */
     fn.add_faux_rows = function(rows) {
         var actual_rows = this.rows;
-        var max_rows = actual_rows + (rows || 1);
+        var max_rows = actual_rows + parseInt(rows || 1);
 
         for (var r = max_rows; r > actual_rows; r--) {
             for (var c = this.cols; c >= 1; c--) {

--- a/src/jquery.gridster.js
+++ b/src/jquery.gridster.js
@@ -2986,7 +2986,7 @@
     */
     fn.add_faux_cols = function(cols) {
         var actual_cols = this.cols;
-        var max_cols = actual_cols + (cols || 1);
+        var max_cols = actual_cols + parseInt(cols || 1);
         max_cols = Math.min(max_cols, this.options.max_cols);
 
         for (var c = actual_cols + 1; c <= max_cols; c++) {


### PR DESCRIPTION
This solves https://github.com/ducksboard/gridster.js/issues/425.

The 
    fn.add_faux_rows = function(rows) {
        var actual_rows = this.rows;
        var max_rows = actual_rows + (rows || 1);

The second part was being added as a string before this patch.  This gave a huge row number and caused lots of lags.  Now it flies again.

I think also related to:

https://github.com/ducksboard/gridster.js/issues/340  (see comments of canfiax)
