### PR TITLE
Fix a bug in Gridster.add_faux_cell method

### DIFF
--- a/src/jquery.gridster.js
+++ b/src/jquery.gridster.js
@@ -2944,8 +2944,10 @@
             this.gridmap[col] = [];
         }
 
-        this.gridmap[col][row] = false;
-        this.faux_grid.push(coords);
+        if (this.gridmap[col].length <= row) {
+            this.gridmap[col][row] = false;
+            this.faux_grid.push(coords);
+        }
 
         return this;
     };


### PR DESCRIPTION
This line checks that the row doesn't already exist in the gridmap array; if it does then it doesn't need to be pushed to the faux_grid array.

Otherwise, this function introduced a bug when I was dynamically adding widgets that had a row height > 1 as the first widget added. This function would overwrite it's second row entry with "false", making it seem that no element was in row 2, when actually there was. Any subsequent widget added would end up being at row 2 (rather than row 3, as the first widget already occupied the first 2 rows) because Gridster doesn't know that a widget was there.
