### PR TITLE
fix (Gridster.js):  destroy  resize_api

### DIFF
--- a/src/jquery.gridster.js
+++ b/src/jquery.gridster.js
@@ -3118,6 +3118,10 @@
             this.drag_api.destroy();
         }
 
+        if (this.resize_api) {
+            this.resize_api.destroy();
+        }
+
         this.remove_style_tags();
 
         remove && this.$el.remove();


### PR DESCRIPTION
Call  resize_api.destroy()  to fix  memory leak.
