### PR TITLE
Moved jQuery to peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,8 +22,8 @@
     }
   ],
   "keywords": [],
-  "dependencies": {
-    "jquery": "git+https://github.com/jquery/jquery.git#2.0.3"
+  "peerDependencies": {
+    "jquery": "*"
   },
   "devDependencies": {
     "grunt": "~0.4.1",


### PR DESCRIPTION
If Gridster relies on its own version of jQuery, then we are faced with two problems
- if the parent module also relies on jQuery, then the final Browserify/Webpack build will embed two different versions of jQuery
- we will have two JavaScript (pointer) references to jQuery. This means that there are cases where initializing a jQuery object in one source file will yield an entirely different instance when initializing from another, e.g. in file 1, we do `var foo = $('css selector')`, and in file two, we refer to `foo` somehow, and yet, running `foo instanceof jQuery` will be false. I'm oversimplifying the problem, but I did come across the exact same issue because a child module was not a peer dependency.
