### PR TITLE
fix(method): destructor incomplete

### DIFF
--- a/src/jquery.gridster.js
+++ b/src/jquery.gridster.js
@@ -3117,7 +3117,10 @@
         if (this.drag_api) {
             this.drag_api.destroy();
         }
-
+		if(this.resize_api) {
+            this.resize_api.destroy();
+        }
+        
         this.remove_style_tags();
 
         remove && this.$el.remove();


### PR DESCRIPTION
change gridster destructor to properly clean up resize events and prevent possible "RangeError: Maximum call stack size exceeded" error in Ember/MVC applications

Closes #527
