### PR TITLE
Extend grid properly vertically (add_faux_cell fix)

### DIFF
--- a/src/jquery.gridster.js
+++ b/src/jquery.gridster.js
@@ -2944,7 +2944,10 @@
             this.gridmap[col] = [];
         }
 
-        this.gridmap[col][row] = false;
+        if (this.gridmap[col].length <= row) {
+            this.gridmap[col][row] = false;
+        }
+
         this.faux_grid.push(coords);
 
         return this;


### PR DESCRIPTION
This PR fixes https://github.com/ducksboard/gridster.js/issues/580
The solution is similar to: https://github.com/ducksboard/gridster.js/pull/440 ,but after applying the fix from 440 my grid started behaving crazy.

This change did the job for my case, hopefully it works for all cases.
Cheers
